### PR TITLE
Count the number requests matching an interactions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The mock service provides the following endpoints:
 * POST /interactions - set up an expected interaction
 * PUT /interactions - clear and set up multiple expected interactions in one call
 * GET /interactions/verification - determine whether the expected interactions have taken place
+* GET /interactions/matches - determine the count of the number of requests matching interactions
 * POST /pact - write the pact file
 * GET / - the healthcheck endpoint
 

--- a/lib/pact/mock_service/request_handlers.rb
+++ b/lib/pact/mock_service/request_handlers.rb
@@ -9,6 +9,7 @@ require 'pact/mock_service/request_handlers/missing_interactions_get'
 require 'pact/mock_service/request_handlers/pact_post'
 require 'pact/mock_service/request_handlers/session_delete'
 require 'pact/mock_service/request_handlers/verification_get'
+require 'pact/mock_service/request_handlers/matches_get'
 require 'pact/consumer/request'
 require 'pact/support'
 
@@ -27,6 +28,7 @@ module Pact
             SessionDelete.new(name, logger, session),
             MissingInteractionsGet.new(name, logger, session),
             VerificationGet.new(name, logger, session),
+            MatchesGet.new(name, logger, session),
             InteractionPost.new(name, logger, session, Pact::SpecificationVersion.new(options.fetch(:pact_specification_version))),
             InteractionsPut.new(name, logger, session, Pact::SpecificationVersion.new(options.fetch(:pact_specification_version))),
             InteractionDelete.new(name, logger, session),

--- a/lib/pact/mock_service/request_handlers/matches_get.rb
+++ b/lib/pact/mock_service/request_handlers/matches_get.rb
@@ -1,0 +1,41 @@
+require 'pact/mock_service/request_handlers/base_administration_request_handler'
+require 'json'
+
+module Pact
+  module MockService
+    module RequestHandlers
+      class MatchesGet < BaseAdministrationRequestHandler
+
+        def initialize name, logger, session
+          super name, logger
+          @expected_interactions = session.expected_interactions
+          @actual_interactions = session.actual_interactions
+        end
+
+        def request_path
+          '/interactions/matches'
+        end
+
+        def request_method
+          'GET'
+        end
+
+        def respond env
+          result = expected_interactions.map{|x| {
+              :description    => x.description,
+              :request        => x.request.to_hash,
+              :number_matches => actual_interactions.matched_interactions.
+                        select{ |y| y.description == x.description }.
+                        count
+
+          }}
+          json_response(result.to_json)
+        end
+
+        private
+
+        attr_accessor :expected_interactions, :actual_interactions
+      end
+    end
+  end
+end

--- a/spec/features/administration_endpoints_cors_spec.rb
+++ b/spec/features/administration_endpoints_cors_spec.rb
@@ -102,6 +102,11 @@ describe Pact::Consumer::MockService do
         expect(last_response.headers['Access-Control-Allow-Origin']).to eq '*'
       end
 
+      it "includes the CORS headers in the response to GET /interactions/matches" do | example |
+        get "/interactions/matches", nil, admin_headers
+        expect(last_response.headers['Access-Control-Allow-Origin']).to eq '*'
+      end
+
       context "when the Origin header is set" do
         it "sets the Access-Control-Allow-Origin header to be the Origin" do
           options '/pact', nil, { 'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'X-Pact-Mock-Service, Content-Type', 'HTTP_ORIGIN' => 'http://localhost:1234' }


### PR DESCRIPTION
On this PR we coded an additional feature for `pact-mock-service` that
allow the users to know how many times an interaction matched. This can
be useful in scenarios where we need to call the same interaction 
multiple times and we need to validate the number of calls.

The output looks like:

```json
[
  { 
    "description": "InteractionDescription1",
    "request": {
       "path": "/test",
       "method":"GET"
    },
    "number_matches": 3,
  },
  ....
]
```